### PR TITLE
Release/1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Changelog
 
+**1.2.0**
+
+- ExpressionBuilder class: change expression property visibility to protected (so other classes can access it)
+
 **1.1.0**
 
 - Fixed regression in task sourcesJar from 1.0.0

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ allprojects {
 }
 
 dependencies {
-    compile 'com.github.burnett01:kotlin-expression-builder:1.1.0'
+    compile 'com.github.burnett01:kotlin-expression-builder:1.2.0'
 }
 ```
 
@@ -247,7 +247,7 @@ Maven dependency:
 <dependency>
     <groupId>com.github.Burnett01</groupId>
     <artifactId>kotlin-expression-builder</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ class main {
 }
 ```
 
-To be continued...
-
 ---
 
 ## Setup / Install
@@ -260,7 +258,7 @@ Check [here](https://jitpack.io/#Burnett01/kotlin-expression-builder/) for more.
 
 ### Gradle
 
-```gradle build```
+```gradlew build```
 
 ---
 
@@ -281,7 +279,7 @@ Various tests are performed to make sure this package runs as smoothly as possib
 
 ### Gradle
 
-```gradle test```
+```gradlew test```
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,8 @@
 ## Supported Versions
 
 | Version | Supported          |
-| ------- | ------------------ |
+| ------- | ------------------ |+
+| 1.2.x   | :white_check_mark: |
 | 1.1.x   | :white_check_mark: |
 | 1.0.x   | :white_check_mark: |
 | 0.8   | :white_check_mark: |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.5.30'
-    ext.kotest_version = '4.6.2'
+    ext.kotest_version = '4.6.3'
 }
 
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.30'
+    ext.kotlin_version = '1.5.31'
     ext.kotest_version = '4.6.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'com.github.burnett01'
-version = '1.1.0'
+version = '1.2.0'
 
 publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.5.30'
     ext.kotest_version = '4.6.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.5.30'
     ext.kotest_version = '4.6.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.5.30'
-    ext.kotest_version = '4.6.0'
+    ext.kotlin_version = '1.5.20'
+    ext.kotest_version = '4.6.2'
 }
 
 plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/burnett01/expression/ExpressionBuilder.kt
+++ b/src/main/kotlin/com/github/burnett01/expression/ExpressionBuilder.kt
@@ -51,7 +51,7 @@ open class ExpressionBuilder() {
     /**
      * @property: expression | Final expression
      */
-    private val expression: Expression? by lazy {
+    protected val expression: Expression? by lazy {
         Expression(opts)
     }
 


### PR DESCRIPTION
+ feat: (ExpressionBuilder) change expression val visibility from private to protected
+ chore: Bump kotlin_version from 1.5.20 to 1.5.31
+ chore: Bump kotest-runner-junit5 from 4.6.0 to 4.6.3